### PR TITLE
service: fix access of _isOptedIn variable of OptInService contract

### DIFF
--- a/src/contracts/service/OptInService.sol
+++ b/src/contracts/service/OptInService.sol
@@ -23,7 +23,7 @@ contract OptInService is StaticDelegateCallable, IOptInService {
      */
     address public immutable WHERE_REGISTRY;
 
-    mapping(address who => mapping(address where => Checkpoints.Trace208 value)) public _isOptedIn;
+    mapping(address who => mapping(address where => Checkpoints.Trace208 value)) internal _isOptedIn;
 
     constructor(address whoRegistry, address whereRegistry) {
         WHO_REGISTRY = whoRegistry;

--- a/src/interfaces/IVaultConfigurator.sol
+++ b/src/interfaces/IVaultConfigurator.sol
@@ -7,7 +7,7 @@ interface IVaultConfigurator {
     error DirtyInitParams();
 
     /**
-     * @notice Initial parameters needed for a vault with a delegator and a slashher deployment.
+     * @notice Initial parameters needed for a vault with a delegator and a slasher deployment.
      * @param version entity's version to use
      * @param owner initial owner of the entity
      * @param vaultParams parameters for the vault initialization

--- a/src/interfaces/vault/IVaultStorage.sol
+++ b/src/interfaces/vault/IVaultStorage.sol
@@ -18,14 +18,14 @@ interface IVaultStorage {
     function DEPOSITOR_WHITELIST_ROLE() external view returns (bytes32);
 
     /**
-     * @notice Get the delegator fatory's address.
-     * @return address of the delegator fatory
+     * @notice Get the delegator factory's address.
+     * @return address of the delegator factory
      */
     function DELEGATOR_FACTORY() external view returns (address);
 
     /**
-     * @notice Get the slasher fatory's address.
-     * @return address of the slasher fatory
+     * @notice Get the slasher factory's address.
+     * @return address of the slasher factory
      */
     function SLASHER_FACTORY() external view returns (address);
 


### PR DESCRIPTION
Fixes access of `_isOptedIn` variable of OptInService contract from public to internal. 

Found this issue while generating go bindings of this contract as the name conflicts with `isOptedIn` public function which led to failure in generating go bindings.

Also fixes some spellings in comments.