### PR TITLE
chore: floating pragma only for interfaces/libs

### DIFF
--- a/src/contracts/libraries/Checkpoints.sol
+++ b/src/contracts/libraries/Checkpoints.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 import {Checkpoints as OZCheckpoints} from "@openzeppelin/contracts/utils/structs/Checkpoints.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";

--- a/src/contracts/libraries/ERC4626Math.sol
+++ b/src/contracts/libraries/ERC4626Math.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 

--- a/src/contracts/libraries/Subnetwork.sol
+++ b/src/contracts/libraries/Subnetwork.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 /**
  * @dev This library adds functions to work with subnetworks.

--- a/src/interfaces/IDelegatorFactory.sol
+++ b/src/interfaces/IDelegatorFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 import {IFactory} from "./common/IFactory.sol";
 

--- a/src/interfaces/INetworkRegistry.sol
+++ b/src/interfaces/INetworkRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 import {IRegistry} from "./common/IRegistry.sol";
 

--- a/src/interfaces/IOperatorRegistry.sol
+++ b/src/interfaces/IOperatorRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 import {IRegistry} from "./common/IRegistry.sol";
 

--- a/src/interfaces/ISlasherFactory.sol
+++ b/src/interfaces/ISlasherFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 import {IFactory} from "./common/IFactory.sol";
 

--- a/src/interfaces/IVaultConfigurator.sol
+++ b/src/interfaces/IVaultConfigurator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 import {IVault} from "./vault/IVault.sol";
 

--- a/src/interfaces/IVaultFactory.sol
+++ b/src/interfaces/IVaultFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 import {IMigratablesFactory} from "./common/IMigratablesFactory.sol";
 

--- a/src/interfaces/collateral/ICollateral.sol
+++ b/src/interfaces/collateral/ICollateral.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/src/interfaces/common/IEntity.sol
+++ b/src/interfaces/common/IEntity.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 interface IEntity {
     /**

--- a/src/interfaces/common/IFactory.sol
+++ b/src/interfaces/common/IFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 import {IRegistry} from "./IRegistry.sol";
 

--- a/src/interfaces/common/IMigratableEntity.sol
+++ b/src/interfaces/common/IMigratableEntity.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 interface IMigratableEntity {
     error AlreadyInitialized();

--- a/src/interfaces/common/IMigratableEntityProxy.sol
+++ b/src/interfaces/common/IMigratableEntityProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 import {IERC1967} from "@openzeppelin/contracts/interfaces/IERC1967.sol";
 

--- a/src/interfaces/common/IMigratablesFactory.sol
+++ b/src/interfaces/common/IMigratablesFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 import {IRegistry} from "./IRegistry.sol";
 

--- a/src/interfaces/common/IRegistry.sol
+++ b/src/interfaces/common/IRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 interface IRegistry {
     error EntityNotExist();

--- a/src/interfaces/delegator/IBaseDelegator.sol
+++ b/src/interfaces/delegator/IBaseDelegator.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 interface IBaseDelegator {
     error AlreadySet();

--- a/src/interfaces/delegator/IDelegatorHook.sol
+++ b/src/interfaces/delegator/IDelegatorHook.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 interface IDelegatorHook {
     /**

--- a/src/interfaces/delegator/IFullRestakeDelegator.sol
+++ b/src/interfaces/delegator/IFullRestakeDelegator.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 import {IBaseDelegator} from "./IBaseDelegator.sol";
 

--- a/src/interfaces/delegator/INetworkRestakeDelegator.sol
+++ b/src/interfaces/delegator/INetworkRestakeDelegator.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 import {IBaseDelegator} from "./IBaseDelegator.sol";
 

--- a/src/interfaces/service/IMetadataService.sol
+++ b/src/interfaces/service/IMetadataService.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 interface IMetadataService {
     error AlreadySet();

--- a/src/interfaces/service/INetworkMiddlewareService.sol
+++ b/src/interfaces/service/INetworkMiddlewareService.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 interface INetworkMiddlewareService {
     error AlreadySet();

--- a/src/interfaces/service/IOptInService.sol
+++ b/src/interfaces/service/IOptInService.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 interface IOptInService {
     error AlreadyOptedIn();

--- a/src/interfaces/slasher/IBaseSlasher.sol
+++ b/src/interfaces/slasher/IBaseSlasher.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 interface IBaseSlasher {
     error NotNetworkMiddleware();

--- a/src/interfaces/slasher/ISlasher.sol
+++ b/src/interfaces/slasher/ISlasher.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 interface ISlasher {
     error InsufficientSlash();

--- a/src/interfaces/slasher/IVetoSlasher.sol
+++ b/src/interfaces/slasher/IVetoSlasher.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 interface IVetoSlasher {
     error InsufficientSlash();

--- a/src/interfaces/vault/IVault.sol
+++ b/src/interfaces/vault/IVault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 import {IVaultStorage} from "./IVaultStorage.sol";
 

--- a/src/interfaces/vault/IVaultStorage.sol
+++ b/src/interfaces/vault/IVaultStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 interface IVaultStorage {
     error InvalidTimestamp();


### PR DESCRIPTION
Changes solidity pragma for interfaces and libs to `^0.8.25;` to enable external code like network middleware to use solidity versions newer than 0.8.25 