### PR TITLE
feat: version enum for delegators

### DIFF
--- a/src/contracts/delegator/BaseDelegator.sol
+++ b/src/contracts/delegator/BaseDelegator.sol
@@ -25,11 +25,6 @@ contract BaseDelegator is Entity, StaticDelegateCallable, AccessControlUpgradeab
     /**
      * @inheritdoc IBaseDelegator
      */
-    uint64 public constant VERSION = 1;
-
-    /**
-     * @inheritdoc IBaseDelegator
-     */
     bytes32 public constant HOOK_SET_ROLE = keccak256("HOOK_SET_ROLE");
 
     /**
@@ -221,4 +216,11 @@ contract BaseDelegator is Entity, StaticDelegateCallable, AccessControlUpgradeab
         address vault_,
         bytes memory data
     ) internal virtual returns (IBaseDelegator.BaseParams memory) {}
+
+    /**
+     * @inheritdoc IBaseDelegator
+     */
+    function VERSION() public pure virtual returns (DelegatorVersion) {
+        return DelegatorVersion.Base;
+    }
 }

--- a/src/contracts/delegator/FullRestakeDelegator.sol
+++ b/src/contracts/delegator/FullRestakeDelegator.sol
@@ -17,6 +17,13 @@ contract FullRestakeDelegator is BaseDelegator, IFullRestakeDelegator {
     using Math for uint256;
 
     /**
+     * @inheritdoc IBaseDelegator
+     */
+    function VERSION() public pure override(BaseDelegator, IBaseDelegator) returns (DelegatorVersion) {
+        return DelegatorVersion.FullRestake;
+    }
+
+    /**
      * @inheritdoc IFullRestakeDelegator
      */
     bytes32 public constant NETWORK_LIMIT_SET_ROLE = keccak256("NETWORK_LIMIT_SET_ROLE");

--- a/src/contracts/delegator/NetworkRestakeDelegator.sol
+++ b/src/contracts/delegator/NetworkRestakeDelegator.sol
@@ -17,6 +17,13 @@ contract NetworkRestakeDelegator is BaseDelegator, INetworkRestakeDelegator {
     using Math for uint256;
 
     /**
+     * @inheritdoc IBaseDelegator
+     */
+    function VERSION() public pure override(BaseDelegator, IBaseDelegator) returns (DelegatorVersion) {
+        return DelegatorVersion.NetworkRestake;
+    }
+
+    /**
      * @inheritdoc INetworkRestakeDelegator
      */
     bytes32 public constant NETWORK_LIMIT_SET_ROLE = keccak256("NETWORK_LIMIT_SET_ROLE");

--- a/src/interfaces/delegator/IBaseDelegator.sol
+++ b/src/interfaces/delegator/IBaseDelegator.sol
@@ -6,6 +6,13 @@ interface IBaseDelegator {
     error NotSlasher();
     error NotVault();
 
+    enum DelegatorVersion {
+        Unspecified,
+        Base,
+        NetworkRestake,
+        FullRestake
+    }
+
     /**
      * @notice Base parameters needed for delegators' deployment.
      * @param defaultAdminRoleHolder address of the initial DEFAULT_ADMIN_ROLE holder
@@ -52,9 +59,8 @@ interface IBaseDelegator {
     /**
      * @notice Get a version of the delegator (different versions mean different interfaces).
      * @return version of the delegator
-     * @dev Must return 1 for this one.
      */
-    function VERSION() external view returns (uint64);
+    function VERSION() external pure returns (DelegatorVersion);
 
     /**
      * @notice Get the network registry's address.

--- a/test/delegator/FullRestakeDelegator.t.sol
+++ b/test/delegator/FullRestakeDelegator.t.sol
@@ -147,7 +147,7 @@ contract FullRestakeDelegatorTest is Test {
 
         (vault, delegator) = _getVaultAndDelegator(epochDuration);
 
-        assertEq(delegator.VERSION(), 1);
+        assertEq(uint8(delegator.VERSION()), uint8(IBaseDelegator.DelegatorVersion.FullRestake));
         assertEq(delegator.NETWORK_REGISTRY(), address(networkRegistry));
         assertEq(delegator.VAULT_FACTORY(), address(vaultFactory));
         assertEq(delegator.OPERATOR_VAULT_OPT_IN_SERVICE(), address(operatorVaultOptInService));

--- a/test/delegator/NetworkRestakeDelegator.t.sol
+++ b/test/delegator/NetworkRestakeDelegator.t.sol
@@ -148,7 +148,7 @@ contract NetworkRestakeDelegatorTest is Test {
 
         (vault, delegator) = _getVaultAndDelegator(epochDuration);
 
-        assertEq(delegator.VERSION(), 1);
+        assertEq(uint8(delegator.VERSION()), uint8(IBaseDelegator.DelegatorVersion.NetworkRestake));
         assertEq(delegator.NETWORK_REGISTRY(), address(networkRegistry));
         assertEq(delegator.VAULT_FACTORY(), address(vaultFactory));
         assertEq(delegator.OPERATOR_VAULT_OPT_IN_SERVICE(), address(operatorVaultOptInService));


### PR DESCRIPTION
Adds version enum for delegator contracts to delineate their type. This enables a `IBaseDelegator` contract to be downcast to its appropriate type