### PR TITLE
Handle malformed checkpoint hints

### DIFF
--- a/src/contracts/libraries/Checkpoints.sol
+++ b/src/contracts/libraries/Checkpoints.sol
@@ -57,7 +57,7 @@ library Checkpoints {
      * (index of the checkpoint with a key lower or equal than the search key).
      */
     function upperLookupRecent(Trace208 storage self, uint48 key, bytes memory hint_) internal view returns (uint208) {
-        if (hint_.length == 0) {
+        if (hint_.length != 32) {
             return upperLookupRecent(self, key);
         }
 
@@ -119,7 +119,7 @@ library Checkpoints {
         view
         returns (bool, uint48, uint208, uint32)
     {
-        if (hint_.length == 0) {
+        if (hint_.length != 32) {
             return upperLookupRecentCheckpoint(self, key);
         }
 
@@ -215,7 +215,7 @@ library Checkpoints {
      * (index of the checkpoint with a key lower or equal than the search key).
      */
     function upperLookupRecent(Trace256 storage self, uint48 key, bytes memory hint_) internal view returns (uint256) {
-        if (hint_.length == 0) {
+        if (hint_.length != 32) {
             return upperLookupRecent(self, key);
         }
 
@@ -277,7 +277,7 @@ library Checkpoints {
         view
         returns (bool, uint48, uint256, uint32)
     {
-        if (hint_.length == 0) {
+        if (hint_.length != 32) {
             return upperLookupRecentCheckpoint(self, key);
         }
 

--- a/test/libraries/Checkpoints.t.sol
+++ b/test/libraries/Checkpoints.t.sol
@@ -158,6 +158,33 @@ contract CheckpointsTrace208Test is Test {
         assertEq(resultWithHint, resultWithoutHint);
     }
 
+
+    function testUpperLookupRecentWithMalformedHintFallsBack() public {
+        _ckpts.push(10, 100);
+        _ckpts.push(20, 200);
+
+        bytes memory malformedHint = hex"01";
+
+        assertEq(_ckpts.upperLookupRecent(15, malformedHint), _ckpts.upperLookupRecent(15));
+    }
+
+    function testUpperLookupRecentCheckpointWithMalformedHintFallsBack() public {
+        _ckpts.push(10, 100);
+        _ckpts.push(20, 200);
+
+        bytes memory malformedHint = hex"01";
+
+        (bool existsWithHint, uint48 keyWithHint, uint208 valueWithHint, uint32 indexWithHint) =
+            _ckpts.upperLookupRecentCheckpoint(15, malformedHint);
+        (bool existsWithoutHint, uint48 keyWithoutHint, uint208 valueWithoutHint, uint32 indexWithoutHint) =
+            _ckpts.upperLookupRecentCheckpoint(15);
+
+        assertEq(existsWithHint, existsWithoutHint);
+        assertEq(keyWithHint, keyWithoutHint);
+        assertEq(valueWithHint, valueWithoutHint);
+        assertEq(indexWithHint, indexWithoutHint);
+    }
+
     // Test upperLookupRecentCheckpoint without hint
     function testUpperLookupRecentCheckpoint(uint48[] memory keys, uint208[] memory values, uint48 lookup) public {
         vm.assume(values.length > 0 && values.length <= keys.length);
@@ -465,6 +492,33 @@ contract CheckpointsTrace256Test is Test {
         uint256 resultWithoutHint = _ckpts.upperLookupRecent(lookup);
 
         assertEq(resultWithHint, resultWithoutHint);
+    }
+
+
+    function testUpperLookupRecentWithMalformedHintFallsBack() public {
+        _ckpts.push(10, 100);
+        _ckpts.push(20, 200);
+
+        bytes memory malformedHint = hex"01";
+
+        assertEq(_ckpts.upperLookupRecent(15, malformedHint), _ckpts.upperLookupRecent(15));
+    }
+
+    function testUpperLookupRecentCheckpointWithMalformedHintFallsBack() public {
+        _ckpts.push(10, 100);
+        _ckpts.push(20, 200);
+
+        bytes memory malformedHint = hex"01";
+
+        (bool existsWithHint, uint48 keyWithHint, uint256 valueWithHint, uint32 indexWithHint) =
+            _ckpts.upperLookupRecentCheckpoint(15, malformedHint);
+        (bool existsWithoutHint, uint48 keyWithoutHint, uint256 valueWithoutHint, uint32 indexWithoutHint) =
+            _ckpts.upperLookupRecentCheckpoint(15);
+
+        assertEq(existsWithHint, existsWithoutHint);
+        assertEq(keyWithHint, keyWithoutHint);
+        assertEq(valueWithHint, valueWithoutHint);
+        assertEq(indexWithHint, indexWithoutHint);
     }
 
     // Test upperLookupRecentCheckpoint without hint


### PR DESCRIPTION
Checkpoint lookups with hints currently fall back only for an empty hint. A non-empty malformed hint is decoded as `uint32`, so callers can hit an ABI decode revert instead of getting the same safe fallback behavior used for missing hints.

This treats hints as usable only when they are exactly one ABI word. Malformed hints now fall back to the normal lookup path, and the tests cover both Trace208 and Trace256 hint helpers.