### PR TITLE
docs: fix script name mismatch in Safe multisig example

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Interaction with different actions is similar; let's consider [SetNetworkLimit](
    - If you use a Safe multisig and want to get a transaction calldata:
 
      ```bash
-     forge script script/actions/SetMaxNetworkLimit.s.sol --rpc-url <RPC_URL> --sender <MULTISIG_ADDRESS> --unlocked
+     forge script script/actions/SetNetworkLimit.s.sol --rpc-url <RPC_URL> --sender <MULTISIG_ADDRESS> --unlocked
      ```
 
      In the logs, you will see `data` and `target` fields like this:


### PR DESCRIPTION
## Description
Fix incorrect script name in `README.md` where the Safe multisig calldata generation command references `SetMaxNetworkLimit.s.sol` instead of `SetNetworkLimit.s.sol`.

The entire section uses `SetNetworkLimit` as the example:
- Header: "let's consider SetNetworkLimit as an example"
- Configuration: "Open SetNetworkLimit.s.sol"  
- Log output: "SetNetworkLimit data:"
- EOA execution: uses correct `SetNetworkLimit.s.sol`

However, the Safe multisig command incorrectly uses `SetMaxNetworkLimit.s.sol`.

## Changes
- Replace `SetMaxNetworkLimit.s.sol` with `SetNetworkLimit.s.sol`
- Aligns with the documented example and other commands in the same section