### PR TITLE
ci: retry rate-limited fork suites instead of failing the run

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -96,8 +96,34 @@ jobs:
             ${{ runner.os }}-foundry-rpc-mainnet-${{ env.MAINNET_FORK_BLOCK }}-${{ matrix.suite.id }}
             ${{ runner.os }}-foundry-rpc-mainnet-${{ env.MAINNET_FORK_BLOCK }}-
 
+      # A cold RPC cache makes the first attempt fetch every mainnet slot at once, which trips the
+      # provider rate limit (HTTP 429). Foundry persists each response it does get to ~/.foundry/cache/rpc,
+      # so every attempt starts warmer and needs fewer live requests - retrying in-job is what converges.
+      # A fresh workflow run would not: Actions scopes caches per ref and main cannot read the ones a PR
+      # branch wrote, so the first run after every merge starts cold. Only 429s are retried; any other
+      # failure is a real one and exits immediately.
       - name: Run Forge mainnet tests
-        run: ${{ matrix.suite.command }} $FORK_TEST_FLAGS
+        run: |
+          log="$RUNNER_TEMP/forge-attempt.log"
+          for attempt in 1 2 3; do
+            set +e
+            ${{ matrix.suite.command }} $FORK_TEST_FLAGS 2>&1 | tee "$log"
+            status=${PIPESTATUS[0]}
+            set -e
+            if [ "$status" -eq 0 ]; then
+              exit 0
+            fi
+            if ! grep -q 'HTTP error 429' "$log"; then
+              echo "::error::Attempt $attempt failed for reasons other than provider rate limiting."
+              exit "$status"
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "::warning::Attempt $attempt hit HTTP 429; backing off $((attempt * 60))s, then retrying with a warmer RPC cache."
+              sleep "$((attempt * 60))"
+            fi
+          done
+          echo "::error::Provider rate limit persisted across 3 attempts."
+          exit 1
 
       - name: Save Foundry RPC cache
         if: always()


### PR DESCRIPTION
## Problem

The first `test` run on `main` after every merge fails, and the cause is not the code under test.

Actions scopes caches per ref, and **main cannot read cache entries a PR branch wrote**. So the post-merge run starts with a cold Foundry RPC cache, the mainnet suites fetch all fork state at once, and the provider answers HTTP 429:

```
[FAIL: vm.createSelectFork: could not instantiate forked environment with provider
eth-mainnet.g.alchemy.com; Max retries exceeded HTTP error 429
```

Same commits, two different outcomes — the only difference is the cache:

| | PR run (green) | main push (red) |
|---|---|---|
| Foundry RPC cache | `Cache restored successfully`, ~2 MB | `Cache not found for input keys` |
| Result | all suites pass, 2m0s | 429 across the suite, 6m8s |

This is structural, not a one-off: [run 31197476561](https://github.com/symbioticfi/core/actions/runs/31197476561) (merge of #136) and [run 31138998090](https://github.com/symbioticfi/core/actions/runs/31138998090) (merge of #135) failed the same way.

Note the `Unauthorized request to eth-mainnet.g.alchemy.com` annotations on those runs are bullfrog audit-mode noise and a red herring — the requests went through, which is how the provider was able to return 429.

## Fix

Retry the forge step up to 3 times with 60s/120s backoff. Foundry persists every response it *does* receive to `~/.foundry/cache/rpc`, so each attempt starts warmer and needs fewer live requests. Retrying in-job converges where a fresh workflow run cannot, because a fresh run on main is cold again by construction.

**Only 429s are retried.** Any other failure exits on the first attempt, so a real regression still reports immediately rather than after three passes and three minutes of backoff.

## Verification

Rendered the step out of the workflow with the matrix expression substituted exactly as Actions would, then ran it under `bash -e` against a stubbed `forge`:

| Scenario | forge invocations | Exit |
|---|---|---|
| 429 twice, then passes | 3 | 0 |
| `EvmError: Revert`, no 429 | 1 — no retry | 1 |
| 429 on every attempt | 3 | 1 |

This also confirmed the matrix command's single-quoted regexes (`'.*Mainnet.*'`) survive substitution into the loop as single arguments.

## Not covered here

This makes cold starts survivable, not rare. A scheduled warm-up run on `main` would fix the other half of the scoping problem — main's caches *are* visible to all branches, so new PR branches would stop starting cold too. Worth stacking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)